### PR TITLE
Undefined type when using Swift v5

### DIFF
--- a/src/ios/Chooser.swift
+++ b/src/ios/Chooser.swift
@@ -51,7 +51,7 @@ class Chooser : CDVPlugin {
 			}
 
 			do {
-				let result = [
+				let result: [String: Any] = [
 					"data": includeData ? data.base64EncodedString() : "",
 					"mediaType": self.detectMimeType(newURL),
 					"name": newURL.lastPathComponent,


### PR DESCRIPTION
Added type "[String: Any]" to variable "result".