### PR TITLE
Gracefully handle Android OOM errors

### DIFF
--- a/src/android/Chooser.java
+++ b/src/android/Chooser.java
@@ -152,5 +152,8 @@ public class Chooser extends CordovaPlugin {
 		catch (Exception err) {
 			this.callback.error("Failed to read file: " + err.toString());
 		}
+		catch (OutOfMemoryError err) {
+		    	this.callback.error("Failed to read file: " + err.toString());
+		}
 	}
 }


### PR DESCRIPTION
Handle out of memory issues on android.

It is currently not catched, because OOM is an error and not a exception (https://stackoverflow.com/a/14812629/7851053)

closes https://github.com/cyph/cordova-plugin-chooser/issues/25

(this atleast prevents app crashes and people can show a error dialog within their cordova app).