### PR TITLE
Dismiss delegate for iOS DocumentPicker

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+	"name": "@uberfusion007/cordova-plugin-chooser",
+	"version": "1.3.3",
+	"lockfileVersion": 2,
+	"requires": true,
+	"packages": {
+		"": {
+			"name": "@uberfusion007/cordova-plugin-chooser",
+			"version": "1.3.3",
+			"license": "Apache-2.0"
+		}
+	}
+}

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
-	"name": "cordova-plugin-chooser",
-	"version": "1.3.2",
+	"name": "@uberfusion007/cordova-plugin-chooser",
+	"version": "1.3.3",
 	"description": "Cordova file chooser plugin",
 	"main": "index.js",
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/cyph/cordova-plugin-chooser.git"
+		"url": "git+https://https://github.com/uberfusion007/cordova-plugin-chooser"
 	},
 	"keywords": [
 		"file",
@@ -29,5 +29,8 @@
 	},
 	"scripts": {
 		"test": "echo \"Error: no test specified\" && exit 1"
+	},
+	"publishConfig": {
+		"registry": "https://npm.pkg.github.com"
 	}
 }

--- a/plugin.xml
+++ b/plugin.xml
@@ -3,7 +3,7 @@
 	xmlns="http://www.phonegap.com/ns/plugins/1.0" 
 	xmlns:android="http://schemas.android.com/apk/res/android" 
 	id="cordova-plugin-chooser" 
-	version="1.3.1"
+	version="1.3.3"
 >	
 	<name>Chooser</name>
 	<author>Cyph, Inc.</author>

--- a/src/ios/Chooser.swift
+++ b/src/ios/Chooser.swift
@@ -14,6 +14,7 @@ class Chooser : CDVPlugin {
 	func callPicker (includeData: Bool, utis: [String]) {
 		let picker = ChooserUIDocumentPickerViewController(documentTypes: utis, in: .import)
 		picker.delegate = self
+        picker.presentationController?.delegate = self
 		picker.includeData = includeData
 		self.viewController.present(picker, animated: true, completion: nil)
 	}
@@ -173,4 +174,10 @@ extension Chooser : UIDocumentPickerDelegate {
 	func documentPickerWasCancelled (_ controller: UIDocumentPickerViewController) {
 		self.send("RESULT_CANCELED")
 	}
+}
+
+extension Chooser : UIAdaptivePresentationControllerDelegate {
+    func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
+        self.send("RESULT_CANCELED")
+    }
 }


### PR DESCRIPTION
Added swipe dismiss delegate for iOS DocumentPicker.

Previously not able to hide custom loading if user swipe down to dismiss picker.